### PR TITLE
#1 @@in chat to default all chats into the global chat

### DIFF
--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -22,7 +22,12 @@ namespace Erenshor_Global_Chat_Mod
                 if (text.Contains("@@"))
                 {
                     Mod.SetWriteIntoGlobalByDefault(!Mod.GetWriteIntoGlobalByDefault());
-                    UpdateSocialLog.LogAdd("<color=purple>[GLOBAL]</color> <color=yellow>Chatting in global chat by default is now " + (Mod.writeIntoGlobalByDefault ? "enabled" : "disabled") + "</color>");
+                    UpdateSocialLog.LogAdd("<color=purple>[GLOBAL]</color> <color=yellow>Chatting in global chat by default is now " + (Mod.GetWriteIntoGlobalByDefault() ? "enabled" : "disabled") + "</color>");
+                    // Reset Player UI
+                    __instance.typed.text = "";
+                    __instance.CDFrames = 10f;
+                    __instance.InputBox.SetActive(value: false);
+                    GameData.PlayerTyping = false;
                     return false;
                 }
                 else if (text[0] == '@')

--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -30,6 +30,17 @@ namespace Erenshor_Global_Chat_Mod
                     __instance.InputBox.SetActive(value: false);
                     GameData.PlayerTyping = false;
                     return false;
+                } else if (text.Contains("@@"))
+                {
+                    Mod.writeIntoGlobalByDefault = !Mod.writeIntoGlobalByDefault;
+                    UpdateSocialLog.LogAdd("Chatting in global chat by default is now " + (Mod.writeIntoGlobalByDefault ? "enabled" : "disabled"));
+                }
+                // When the player types a message, it will be sent to the global chat by default
+                if (Mod.writeIntoGlobalByDefault)
+                {
+                    string message = text.Substring(0);
+                    Mod.SendChatMessageToGlobalServer(message, MelonMod.FindMelon("Erenshor Global Chat Mod", "Lenzork").Info);
+                    return false;
                 }
                 return true;
             }

--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -19,7 +19,13 @@ namespace Erenshor_Global_Chat_Mod
             {
                 string text = __instance.typed.text.ToString();
 
-                if (text[0] == '@')
+                if (text.Contains("@@"))
+                {
+                    Mod.writeIntoGlobalByDefault = !Mod.writeIntoGlobalByDefault;
+                    UpdateSocialLog.LogAdd("<color=purple>[GLOBAL]</color> <color=yellow>Chatting in global chat by default is now " + (Mod.writeIntoGlobalByDefault ? "enabled" : "disabled") + "</color>");
+                    return false;
+                }
+                else if (text[0] == '@')
                 {
                     string message = text.Substring(1);
                     Mod.SendChatMessageToGlobalServer(message, MelonMod.FindMelon("Erenshor Global Chat Mod", "Lenzork").Info);
@@ -30,16 +36,16 @@ namespace Erenshor_Global_Chat_Mod
                     __instance.InputBox.SetActive(value: false);
                     GameData.PlayerTyping = false;
                     return false;
-                } else if (text.Contains("@@"))
-                {
-                    Mod.writeIntoGlobalByDefault = !Mod.writeIntoGlobalByDefault;
-                    UpdateSocialLog.LogAdd("Chatting in global chat by default is now " + (Mod.writeIntoGlobalByDefault ? "enabled" : "disabled"));
-                }
-                // When the player types a message, it will be sent to the global chat by default
-                if (Mod.writeIntoGlobalByDefault)
+                } else if (Mod.writeIntoGlobalByDefault)
                 {
                     string message = text.Substring(0);
                     Mod.SendChatMessageToGlobalServer(message, MelonMod.FindMelon("Erenshor Global Chat Mod", "Lenzork").Info);
+
+                    // Reset Player UI
+                    __instance.typed.text = "";
+                    __instance.CDFrames = 10f;
+                    __instance.InputBox.SetActive(value: false);
+                    GameData.PlayerTyping = false;
                     return false;
                 }
                 return true;

--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -21,7 +21,7 @@ namespace Erenshor_Global_Chat_Mod
 
                 if (text.Contains("@@"))
                 {
-                    Mod.writeIntoGlobalByDefault = !Mod.writeIntoGlobalByDefault;
+                    Mod.SetWriteIntoGlobalByDefault(!Mod.GetWriteIntoGlobalByDefault());
                     UpdateSocialLog.LogAdd("<color=purple>[GLOBAL]</color> <color=yellow>Chatting in global chat by default is now " + (Mod.writeIntoGlobalByDefault ? "enabled" : "disabled") + "</color>");
                     return false;
                 }
@@ -36,7 +36,7 @@ namespace Erenshor_Global_Chat_Mod
                     __instance.InputBox.SetActive(value: false);
                     GameData.PlayerTyping = false;
                     return false;
-                } else if (Mod.writeIntoGlobalByDefault)
+                } else if (Mod.GetWriteIntoGlobalByDefault())
                 {
                     string message = text.Substring(0);
                     Mod.SendChatMessageToGlobalServer(message, MelonMod.FindMelon("Erenshor Global Chat Mod", "Lenzork").Info);

--- a/Erenshor-Global-Chat-Mod/Mod.cs
+++ b/Erenshor-Global-Chat-Mod/Mod.cs
@@ -21,6 +21,7 @@ namespace Erenshor_Global_Chat_Mod
         private static string steamUsername;
         private const string SERVER_IP = "127.0.0.1"; // Enter the IP of the global chat server here
         private bool wrongVersion = false;
+        public static bool writeIntoGlobalByDefault = false;
 
         private static string[] ValidScenes = new string[]
         {

--- a/Erenshor-Global-Chat-Mod/Mod.cs
+++ b/Erenshor-Global-Chat-Mod/Mod.cs
@@ -21,7 +21,7 @@ namespace Erenshor_Global_Chat_Mod
         private static string steamUsername;
         private const string SERVER_IP = "127.0.0.1"; // Enter the IP of the global chat server here
         private bool wrongVersion = false;
-        public static bool writeIntoGlobalByDefault = false;
+        private static bool writeIntoGlobalByDefault = false;
 
         private static string[] ValidScenes = new string[]
         {
@@ -77,6 +77,16 @@ namespace Erenshor_Global_Chat_Mod
             public string SenderName;
             public string Message;
             public string ModVersion;
+        }
+
+        public static bool GetWriteIntoGlobalByDefault()
+        {
+            return writeIntoGlobalByDefault;
+        }
+
+        public static void SetWriteIntoGlobalByDefault(bool value)
+        {
+            writeIntoGlobalByDefault = value;
         }
 
         public override void OnLateInitializeMelon()


### PR DESCRIPTION
This Merge Request Closes #1 

This pull request introduces a new feature to the `Erenshor-Global-Chat-Mod` that allows users to toggle between global chat and local chat by typing `@@` at the beginning of their message. Additionally, it includes a new public static boolean to manage this feature.

Key changes include:

* **Feature Addition: Toggle Global Chat**
  * [`Erenshor-Global-Chat-Mod/MessageHandler.cs`](diffhunk://#diff-a237e00d0b2645c062b55a47d62de0208bc8be74c50e189be267f289cf9d1443L22-R43): Modified the `Prefix` method to check if the typed text contains `@@`. If true, it toggles the `writeIntoGlobalByDefault` flag and updates the social log accordingly.
  * [`Erenshor-Global-Chat-Mod/Mod.cs`](diffhunk://#diff-8d9082ea604b3119c8f79d525e68a7b88d54bebd5a5da65f983a784e2a8a5c80R24): Introduced a new public static boolean `writeIntoGlobalByDefault` to manage the default chat mode.