### PR TITLE
#2 /@online queries all online users

### DIFF
--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -30,7 +30,7 @@ namespace Erenshor_Global_Chat_Mod
                     return false;
                 } else if (text.Contains("/@online"))
                 {
-
+                    Mod.SendRequestForOnlinePlayersToGlobalServer();
 
                     // Reset Player UI
                     resetPlayerUI(__instance);

--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using HarmonyLib;
 using MelonLoader;
 using UnityEngine;
+using static MelonLoader.MelonLogger;
 
 namespace Erenshor_Global_Chat_Mod
 {
@@ -25,13 +26,26 @@ namespace Erenshor_Global_Chat_Mod
                     Mod.SendChatMessageToGlobalServer(message, MelonMod.FindMelon("Erenshor Global Chat Mod", "Lenzork").Info);
 
                     // Reset Player UI
-                    __instance.typed.text = "";
-                    __instance.CDFrames = 10f;
-                    __instance.InputBox.SetActive(value: false);
-                    GameData.PlayerTyping = false;
+                    resetPlayerUI(__instance);
+                    return false;
+                } else if (text.Contains("/@online"))
+                {
+
+
+                    // Reset Player UI
+                    resetPlayerUI(__instance);
                     return false;
                 }
                 return true;
+            }
+
+            private static void resetPlayerUI(TypeText __instance)
+            {
+                // Reset Player UI
+                __instance.typed.text = "";
+                __instance.CDFrames = 10f;
+                __instance.InputBox.SetActive(value: false);
+                GameData.PlayerTyping = false;
             }
         }
     }

--- a/Erenshor-Global-Chat-Mod/MessageHandler.cs
+++ b/Erenshor-Global-Chat-Mod/MessageHandler.cs
@@ -30,7 +30,7 @@ namespace Erenshor_Global_Chat_Mod
                     return false;
                 } else if (text.Contains("/@online"))
                 {
-                    Mod.SendRequestForOnlinePlayersToGlobalServer();
+                    Mod.SendRequestForOnlinePlayersToGlobalServer(MelonMod.FindMelon("Erenshor Global Chat Mod", "Lenzork").Info);
 
                     // Reset Player UI
                     resetPlayerUI(__instance);

--- a/Erenshor-Global-Chat-Mod/Mod.cs
+++ b/Erenshor-Global-Chat-Mod/Mod.cs
@@ -68,7 +68,8 @@ namespace Erenshor_Global_Chat_Mod
             {
                 PlayerConnected,
                 PlayerDisconnected,
-                VersionMismatch
+                VersionMismatch,
+                PlayersOnline
             }
 
             public PackageType Type;
@@ -142,19 +143,23 @@ namespace Erenshor_Global_Chat_Mod
                 ReceiveChatMessage(data);
             } else if(data.Type == PackageData.PackageType.Information)
             {
-                if (data.Info == PackageData.InformationType.PlayerConnected)
+                switch(data.Info)
                 {
-                    UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> <color=yellow>{data.SenderName} has <color=green>connected</color> to the Global Chat.</color>");
-                }
-                else if (data.Info == PackageData.InformationType.PlayerDisconnected)
-                {
-                    UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> <color=yellow>{data.SenderName} has <color=red>disconnected</color> from the Global Chat.</color>");
-                } else if (data.Info == PackageData.InformationType.VersionMismatch)
-                {
-                    MelonLogger.Warning("Disconnected due to Version mismatch with the server.");
-                    UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> {data.Message}");
-                    peer.Disconnect();
-                    wrongVersion = true;
+                    case PackageData.InformationType.PlayerConnected:
+                        UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> <color=yellow>{data.SenderName} has <color=green>connected</color> to the Global Chat.</color>");
+                        break;
+                    case PackageData.InformationType.PlayerDisconnected:
+                        UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> <color=yellow>{data.SenderName} has <color=red>disconnected</color> from the Global Chat.</color>");
+                        break;
+                    case PackageData.InformationType.PlayersOnline:
+                        UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> {data.Message}");
+                        break;
+                    case PackageData.InformationType.VersionMismatch:
+                        MelonLogger.Warning("Disconnected due to Version mismatch with the server.");
+                        UpdateSocialLog.LogAdd($"<color=purple>[GLOBAL]</color> {data.Message}");
+                        peer.Disconnect();
+                        wrongVersion = true;
+                        break;
                 }
             }
         }
@@ -186,6 +191,33 @@ namespace Erenshor_Global_Chat_Mod
                 SenderName = GetSteamUsername(),
                 Message = message,
                 ModVersion = modInfo.Version.ToString()
+            };
+
+            writer.Put(JsonConvert.SerializeObject(data, settings));
+
+            // Send Message to the Server
+            _serverPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+        }
+
+        private void SendRequestForOnlinePlayersToGlobalServer()
+        {
+            if (_serverPeer == null)
+            {
+                MelonLogger.Error("No connection to the Global Chat Server. Couldn't send message.");
+                return;
+            }
+
+            MelonLogger.Msg($"Sending request to see online players to global server");
+
+            var writer = new NetDataWriter();
+            var settings = new JsonSerializerSettings();
+            settings.NullValueHandling = NullValueHandling.Ignore;
+
+            PackageData data = new PackageData
+            {
+                SenderName = GetSteamUsername(),
+                Type = PackageData.PackageType.Information,
+                Info = PackageData.InformationType.PlayersOnline
             };
 
             writer.Put(JsonConvert.SerializeObject(data, settings));

--- a/Erenshor-Global-Chat-Mod/Mod.cs
+++ b/Erenshor-Global-Chat-Mod/Mod.cs
@@ -199,7 +199,7 @@ namespace Erenshor_Global_Chat_Mod
             _serverPeer.Send(writer, DeliveryMethod.ReliableOrdered);
         }
 
-        private void SendRequestForOnlinePlayersToGlobalServer()
+        public static void SendRequestForOnlinePlayersToGlobalServer()
         {
             if (_serverPeer == null)
             {

--- a/Erenshor-Global-Chat-Mod/Mod.cs
+++ b/Erenshor-Global-Chat-Mod/Mod.cs
@@ -199,7 +199,7 @@ namespace Erenshor_Global_Chat_Mod
             _serverPeer.Send(writer, DeliveryMethod.ReliableOrdered);
         }
 
-        public static void SendRequestForOnlinePlayersToGlobalServer()
+        public static void SendRequestForOnlinePlayersToGlobalServer(MelonInfoAttribute modInfo)
         {
             if (_serverPeer == null)
             {
@@ -217,7 +217,8 @@ namespace Erenshor_Global_Chat_Mod
             {
                 SenderName = GetSteamUsername(),
                 Type = PackageData.PackageType.Information,
-                Info = PackageData.InformationType.PlayersOnline
+                Info = PackageData.InformationType.PlayersOnline,
+                ModVersion = modInfo.Version.ToString()
             };
 
             writer.Put(JsonConvert.SerializeObject(data, settings));


### PR DESCRIPTION
- This Merge Request Closes #2 

This pull request introduces several enhancements and refactors to the `Erenshor-Global-Chat-Mod` to improve functionality and maintainability. The key changes include adding a new feature to request online players, refactoring the message handling logic, and adding a utility method to reset the player UI.

### Enhancements:

* Added a new feature to request the list of online players from the global server by sending a specific request message. (`Erenshor-Global-Chat-Mod/MessageHandler.cs`, `Erenshor-Global-Chat-Mod/Mod.cs`) [[1]](diffhunk://#diff-a237e00d0b2645c062b55a47d62de0208bc8be74c50e189be267f289cf9d1443R28-L34) [[2]](diffhunk://#diff-8d9082ea604b3119c8f79d525e68a7b88d54bebd5a5da65f983a784e2a8a5c80R202-R229)

### Refactoring:

* Refactored the `OnNetworkReceive` method to use a switch statement for handling different information types, improving code readability and maintainability. (`Erenshor-Global-Chat-Mod/Mod.cs`)

### Utility Methods:

* Added a `resetPlayerUI` method to encapsulate the logic for resetting the player UI, reducing code duplication. (`Erenshor-Global-Chat-Mod/MessageHandler.cs`)

### Enum Updates:

* Updated the `InformationType` enum to include a new value `PlayersOnline` for the new feature. (`Erenshor-Global-Chat-Mod/Mod.cs`)

### Imports:

* Added a static import for `MelonLogger` to simplify logging calls. (`Erenshor-Global-Chat-Mod/MessageHandler.cs`)